### PR TITLE
blank string and missing attribute handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 
 ### Parameter Types
 
-By declaring parameter types, incoming parameters will automatically be transformed into an object of that type. For instance, if a param is `:boolean`, values of `'1'`, `'true'`, `'t'`, `'yes'`, and `'y'` will be automatically transformed into `true`.
+By declaring parameter types, incoming parameters will automatically be transformed into an object of that type. For instance, if a param is `:boolean`, values of `'1'`, `'true'`, `'t'`, `'yes'`, and `'y'` will be automatically transformed into `true`.  `BigDecimal` defaults to a precision of 14, but this can but changed by passing in the optional `precision:` argument. Any `$` and `,` are automatically stripped when converting to `BigDecimal`.
 
 - `String`
 - `Integer`
@@ -56,6 +56,7 @@ By declaring parameter types, incoming parameters will automatically be transfor
 - `Array` _("1,2,3,4,5")_
 - `Hash` _("key1:value1,key2:value2")_
 - `Date`, `Time`, & `DateTime`
+- `BigDecimal` _("$1,000,000")_
 
 ### Validations
 
@@ -83,6 +84,44 @@ Use the `transform` option to take even more of the business logic of parameter 
 ```ruby
 param! :order, String, in: ["ASC", "DESC"], transform: :upcase, default: "ASC"
 param! :offset, Integer, min: 0, transform: lambda {|n| n - (n % 10)}
+```
+
+### Nested Attributes
+
+rails_param allows you to apply any of the above mentioned validations to attributes nested in hashes:
+
+```ruby
+param! :book, Hash do |b|
+  b.param! :title, String, blank: false
+  b.param! :price, BigDecimal, precision: 4, required: true
+  b.param! :author, Hash, required: true do |a|
+    a.param! :first_name, String
+    a.param! :last_name, String, blank: false
+  end
+end
+```
+
+### Arrays
+
+Validate every element of your array, including nested hashes and arrays:
+
+```ruby
+# primitive datatype syntax
+param! :integer_array, Array do |array,index|
+  array.param! index, Integer, required: true
+end
+
+# complex array
+param! :books_array, Array, required: true  do |b|
+  b.param! :title, String, blank: false
+  b.param! :author, Hash, required: true, do |a|
+    a.param! :first_name, String
+    a.param! :last_name, String, required: true
+  end
+  b.param! :subjects, Array do |s,i|
+    s.param! i, String, blank: false
+  end
+end
 ```
 
 ## Thank you

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ As usual, in your Gemfile...
     param! :categories,  Array
     param! :sort,        String, default: "title"
     param! :order,       String, in: %w(asc desc), transform: :downcase, default: "asc"
-    param! :price,       String, format: "[<\=>]\s*\$\d+"
+    param! :price,       String, format: /[<\=>]\s*\$\d+/
 
     # Access the parameters using the params object (like params[:q]) as you usually do...
   end

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rails makes it easy to deal with HTTP parameters when they are linked to a model
 
 If you are building a complex search form, don’t hesitate to link it to a non-persistent ActiveModel class, like ActiveModel::Model. There are many resources on the Web to learn this kind of good practices, and stay in the “thin controller” rule.
 
-But sometimes, it’s not practical to create an external class just to validate and convert a few parameters. In this case, you may use this gem which allows you to easily do validations and conversion of your params directly in your controller actions using a simple method call.
+But sometimes, it’s not practical to create an external class just to validate and convert a few parameters. In this case, you may use this gem. It allows you to easily do validations and conversion of the parameters directly in your controller actions using a simple method call.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 
 ### Parameter Types
 
-By declaring parameter types, incoming parameters will automatically be transformed into an object of that type. For instance, if a param is `Boolean`, values of `'1'`, `'true'`, `'t'`, `'yes'`, and `'y'` will be automatically transformed into `true`.
+By declaring parameter types, incoming parameters will automatically be transformed into an object of that type. For instance, if a param is `:boolean`, values of `'1'`, `'true'`, `'t'`, `'yes'`, and `'y'` will be automatically transformed into `true`.
 
 - `String`
 - `Integer`

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -181,7 +181,7 @@ describe RailsParam::Param do
     end
 
     describe 'validating nested hash' do
-      it 'typecasts nested attribtues' do
+      it 'typecasts nested attributes' do
         allow(controller).to receive(:params).and_return({'foo' => {'bar' => 1, 'baz' => 2}})
         controller.param! :foo, Hash do |p|
           p.param! :bar, BigDecimal
@@ -189,6 +189,35 @@ describe RailsParam::Param do
         end
         expect(controller.params['foo']['bar']).to be_instance_of BigDecimal
         expect(controller.params['foo']['baz']).to be_instance_of Float
+      end
+
+      it 'does not raise exception if hash is not required but nested attributes are, and no hash is provided' do
+        allow(controller).to receive(:params).and_return(foo: nil)
+        controller.param! :foo, Hash do |p|
+          p.param! :bar, BigDecimal, required: true
+          p.param! :baz, Float, required: true
+        end
+        expect(controller.params['foo']).to be_nil
+      end
+
+      it 'raises exception if hash is required, nested attributes are not required, and no hash is provided' do
+        allow(controller).to receive(:params).and_return(foo: nil)
+        expect {
+          controller.param! :foo, Hash, required: true do |p|
+            p.param! :bar, BigDecimal
+            p.param! :baz, Float
+          end
+        }.to raise_exception
+      end
+
+      it 'raises exception if hash is not required but nested attributes are, and hash has missing attributes' do
+        allow(controller).to receive(:params).and_return({'foo' => {'bar' => 1, 'baz' => nil}})
+        expect {
+          controller.param! :foo, Hash do |p|
+            p.param! :bar, BigDecimal, required: true
+            p.param! :baz, Float, required: true
+          end
+        }.to raise_exception
       end
     end
 
@@ -261,6 +290,25 @@ describe RailsParam::Param do
             a.param! i, Array do |b, e|
               b.param! e, Integer, required: true
             end
+          end
+        }.to raise_exception
+      end
+
+      it 'does not raise exception if array is not required but nested attributes are, and no array is provided' do
+        allow(controller).to receive(:params).and_return(foo: nil)
+        controller.param! :foo, Array do |p|
+          p.param! :bar, BigDecimal, required: true
+          p.param! :baz, Float, required: true
+        end
+        expect(controller.params['foo']).to be_nil
+      end
+
+      it 'raises exception if array is required, nested attributes are not required, and no array is provided' do
+        allow(controller).to receive(:params).and_return(foo: nil)
+        expect {
+          controller.param! :foo, Array, required: true do |p|
+            p.param! :bar, BigDecimal
+            p.param! :baz, Float
           end
         }.to raise_exception
       end


### PR DESCRIPTION
converts blank string to nil unless type = string (in which case returns blank string)
doesn't throw error if array/hash is not required and is missing
specs for empty string and required nested attributes