### PR TITLE
Array coercion: wrap if cannot be splitted

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -14,7 +14,7 @@ module RailsParam
 
     def param!(name, type, options = {}, &block)
       name = name.to_s unless name.is_a? Integer # keep index for validating elements
-      
+
       return unless params.member?(name) || check_param_presence?(options[:default]) || options[:required]
 
       begin
@@ -86,7 +86,15 @@ module RailsParam
         return Date.parse(param) if type == Date
         return Time.parse(param) if type == Time
         return DateTime.parse(param) if type == DateTime
-        return Array(param.split(options[:delimiter] || ",")) if type == Array
+
+        if type == Array
+          if param.respond_to?(:split)
+            return Array(param.split(options[:delimiter] || ","))
+          else
+            return [param]
+          end
+        end
+
         return Hash[param.split(options[:delimiter] || ",").map { |c| c.split(options[:separator] || ":") }] if type == Hash
         return (/^(false|f|no|n|0)$/i === param.to_s ? false : (/^(true|t|yes|y|1)$/i === param.to_s ? true : (raise ArgumentError))) if type == TrueClass || type == FalseClass || type == :boolean
         if type == BigDecimal

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -71,10 +71,16 @@ describe RailsParam::Param do
         expect(controller.params["foo"]).to eql(42.22)
       end
 
-      it "converts to Array" do
+      it "converts to Array when splittable" do
         allow(controller).to receive(:params).and_return({"foo" => "2,3,4,5"})
         controller.param! :foo, Array
         expect(controller.params["foo"]).to eql(["2", "3", "4", "5"])
+      end
+
+      it "wraps in an Array when not splittable" do
+        allow(controller).to receive(:params).and_return({"foo" => 123})
+        controller.param! :foo, Array
+        expect(controller.params["foo"]).to eql([123])
       end
 
       it "converts to Hash" do


### PR DESCRIPTION
Sometimes, params cannot be split into an array (most of non-string types). For those cases, wrapping is usually the expected outcome.

That's what this PR does, with a test.

Let me know if you have remarks about this !
