### PR TITLE
Use Enumerable#include? instead of Hash#member?

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -14,8 +14,8 @@ module RailsParam
 
     def param!(name, type, options = {}, &block)
       name = name.to_s unless name.is_a? Integer # keep index for validating elements
-      
-      return unless params.member?(name) || check_param_presence?(options[:default]) || options[:required]
+
+      return unless params.include?(name) || check_param_presence?(options[:default]) || options[:required]
 
       begin
         params[name] = coerce(params[name], type, options)


### PR DESCRIPTION
This commit will prevent this warning:

```
DEPRECATION WARNING: Method member? is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.0.beta2/classes/ActionController/Parameters.html.
```