### PR TITLE
Add parameter name to error message for easier debugging

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -33,7 +33,7 @@ module RailsParam
         end
 
         # validate
-        validate!(params[name], options)
+        validate!(params[name], name, options)
 
         if block_given?
           if type == Array
@@ -112,13 +112,13 @@ module RailsParam
       end
     end
 
-    def validate!(param, options)
+    def validate!(param, param_name, options)
       options.each do |key, value|
         case key
           when :required
-            raise InvalidParameterError, "Parameter is required" if value && param.nil?
+            raise InvalidParameterError, "Parameter #{param_name} is required" if value && param.nil?
           when :blank
-            raise InvalidParameterError, "Parameter cannot be blank" if !value && case param
+            raise InvalidParameterError, "Parameter #{param_name} cannot be blank" if !value && case param
                                                                                     when String
                                                                                       !(/\S/ === param)
                                                                                     when Array, Hash
@@ -127,25 +127,25 @@ module RailsParam
                                                                                       param.nil?
                                                                                   end
           when :format
-            raise InvalidParameterError, "Parameter must be a string if using the format validation" unless param.kind_of?(String)
-            raise InvalidParameterError, "Parameter must match format #{value}" unless param =~ value
+            raise InvalidParameterError, "Parameter #{param_name} must be a string if using the format validation" unless param.kind_of?(String)
+            raise InvalidParameterError, "Parameter #{param_name} must match format #{value}" unless param =~ value
           when :is
-            raise InvalidParameterError, "Parameter must be #{value}" unless param === value
+            raise InvalidParameterError, "Parameter #{param_name} must be #{value}" unless param === value
           when :in, :within, :range
-            raise InvalidParameterError, "Parameter must be within #{value}" unless param.nil? || case value
+            raise InvalidParameterError, "Parameter #{param_name} must be within #{value}" unless param.nil? || case value
                                                                                                     when Range
                                                                                                       value.include?(param)
                                                                                                     else
                                                                                                       Array(value).include?(param)
                                                                                                   end
           when :min
-            raise InvalidParameterError, "Parameter cannot be less than #{value}" unless param.nil? || value <= param
+            raise InvalidParameterError, "Parameter #{param_name} cannot be less than #{value}" unless param.nil? || value <= param
           when :max
-            raise InvalidParameterError, "Parameter cannot be greater than #{value}" unless param.nil? || value >= param
+            raise InvalidParameterError, "Parameter #{param_name} cannot be greater than #{value}" unless param.nil? || value >= param
           when :min_length
-            raise InvalidParameterError, "Parameter cannot have length less than #{value}" unless param.nil? || value <= param.length
+            raise InvalidParameterError, "Parameter #{param_name} cannot have length less than #{value}" unless param.nil? || value <= param.length
           when :max_length
-            raise InvalidParameterError, "Parameter cannot have length greater than #{value}" unless param.nil? || value >= param.length
+            raise InvalidParameterError, "Parameter #{param_name} cannot have length greater than #{value}" unless param.nil? || value >= param.length
         end
       end
     end

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -334,7 +334,7 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({})
-          expect { controller.param! :price, Integer, required: true }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :price, Integer, required: true }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price is required")
         end
       end
 
@@ -346,7 +346,7 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => ""})
-          expect { controller.param! :price, String, blank: false }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :price, String, blank: false }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price cannot be blank")
         end
       end
 
@@ -358,7 +358,7 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => "50"})
-          expect { controller.param! :price, String, format: /[0-9]+\$/ }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :price, String, format: /[0-9]+\$/ }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price must match format #{/[0-9]+\$/}")
         end
       end
 
@@ -370,7 +370,7 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => "51"})
-          expect { controller.param! :price, String, is: "50" }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :price, String, is: "50" }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price must be 50")
         end
       end
 
@@ -382,7 +382,7 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => "50"})
-          expect { controller.param! :price, Integer, min: 51 }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :price, Integer, min: 51 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price cannot be less than 51")
         end
       end
 
@@ -394,7 +394,7 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => "50"})
-          expect { controller.param! :price, Integer, max: 49 }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :price, Integer, max: 49 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price cannot be greater than 49")
         end
       end
 
@@ -406,7 +406,7 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"word" => "foo"})
-          expect { controller.param! :word, String, min_length: 4 }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :word, String, min_length: 4 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter word cannot have length less than 4")
         end
       end
 
@@ -418,7 +418,7 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"word" => "foo"})
-          expect { controller.param! :word, String, max_length: 2 }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :word, String, max_length: 2 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter word cannot have length greater than 2")
         end
       end
 
@@ -431,7 +431,7 @@ describe RailsParam::Param do
         end
 
         it "raises outside the range" do
-          expect { controller.param! :price, Integer, in: 51..100 }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :price, Integer, in: 51..100 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price must be within 51..100")
         end
       end
     end


### PR DESCRIPTION
### Description

As PR mentions. This gives better error messages to the validations fails to tell the developer which parameter the validation failed on.