### PR TITLE
Adds i18n support to error messages

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -108,7 +108,13 @@ module RailsParam
         end
         return nil
       rescue ArgumentError
-        raise InvalidParameterError, "'#{param}' is not a valid #{type}"
+        raise InvalidParameterError, I18n.t(
+              'invalid',
+              param: param,
+              type: type,
+              default: "'#{param}' is not a valid #{type}",
+              scope: [:rails_param, :type]
+            )
       end
     end
 
@@ -116,39 +122,95 @@ module RailsParam
       options.each do |key, value|
         case key
           when :required
-            raise InvalidParameterError, "Parameter #{param_name} is required" if value && param.nil?
+            raise InvalidParameterError, I18n.t(
+              'required_missing',
+              param_name: param_name,
+              default: "Parameter #{param_name} is required",
+              scope: [:rails_param, :empty]
+            ) if value && param.nil?
           when :blank
-            raise InvalidParameterError, "Parameter #{param_name} cannot be blank" if !value && case param
-                                                                                    when String
-                                                                                      !(/\S/ === param)
-                                                                                    when Array, Hash
-                                                                                      param.empty?
-                                                                                    else
-                                                                                      param.nil?
-                                                                                  end
+            raise InvalidParameterError, I18n.t(
+              'empty',
+              param_name: param_name,
+              default: "Parameter #{param_name} cannot be blank",
+              scope: [:rails_param, :empty]
+            ) if !value && case param
+                             when String
+                               !(/\S/ === param)
+                             when Array, Hash
+                               param.empty?
+                             else
+                               param.nil?
+                           end
           when :format
-            raise InvalidParameterError, "Parameter #{param_name} must be a string if using the format validation" unless param.kind_of?(String)
-            raise InvalidParameterError, "Parameter #{param_name} must match format #{value}" unless param =~ value
+            raise InvalidParameterError, I18n.t(
+              'format_not_string',
+              param_name: param_name,
+              default: "Parameter #{param_name} must be a string if using the format validation",
+              scope: [:rails_param, :format]
+            ) unless param.kind_of?(String)
+            raise InvalidParameterError, I18n.t(
+              'format_not_matching',
+              param_name: param_name,
+              value: value,
+              default: "Parameter #{param_name} must match format #{value}",
+              scope: [:rails_param, :format]
+            ) unless param =~ value
           when :is
-            raise InvalidParameterError, "Parameter #{param_name} must be #{value}" unless param === value
+            raise InvalidParameterError, I18n.t(
+              'format_not_values',
+              param_name: param_name,
+              value: value,
+              default: "Parameter #{param_name} must be #{value}",
+              scope: [:rails_param, :format]
+            ) unless param === value
           when :in, :within, :range
-            raise InvalidParameterError, "Parameter #{param_name} must be within #{value}" unless param.nil? || case value
-                                                                                                    when Range
-                                                                                                      value.include?(param)
-                                                                                                    else
-                                                                                                      Array(value).include?(param)
-                                                                                                  end
+            raise InvalidParameterError, I18n.t(
+              'not_in_range',
+              param_name: param_name,
+              value: value,
+              default: "Parameter #{param_name} must be within #{value}",
+              scope: [:rails_param, :value]
+            ) unless param.nil? || case value
+                                          when Range
+                                            value.include?(param)
+                                          else
+                                            Array(value).include?(param)
+                                        end
           when :min
-            raise InvalidParameterError, "Parameter #{param_name} cannot be less than #{value}" unless param.nil? || value <= param
+            raise InvalidParameterError, I18n.t(
+              'not_less_than',
+              param_name: param_name,
+              value: value,
+              default: "Parameter #{param_name} cannot be less than #{value}",
+              scope: [:rails_param, :value]
+            ) unless param.nil? || value <= param
           when :max
-            raise InvalidParameterError, "Parameter #{param_name} cannot be greater than #{value}" unless param.nil? || value >= param
+            raise InvalidParameterError, I18n.t(
+              'not_greater_than',
+              param_name: param_name,
+              value: value,
+              default: "Parameter #{param_name} cannot be greater than #{value}",
+              scope: [:rails_param, :value]
+            ) unless param.nil? || value >= param
           when :min_length
-            raise InvalidParameterError, "Parameter #{param_name} cannot have length less than #{value}" unless param.nil? || value <= param.length
+            raise InvalidParameterError, I18n.t(
+              'too_short',
+              param_name: param_name,
+              value: value,
+              default: "Parameter #{param_name} cannot have length less than #{value}",
+              scope: [:rails_param, :length]
+            ) unless param.nil? || value <= param.length
           when :max_length
-            raise InvalidParameterError, "Parameter #{param_name} cannot have length greater than #{value}" unless param.nil? || value >= param.length
+            raise InvalidParameterError, I18n.t(
+              'too_big',
+              param_name: param_name,
+              value: value,
+              default: "Parameter #{param_name} cannot have length greater than #{value}",
+              scope: [:rails_param, :length]
+            ) unless param.nil? || value >= param.length
         end
       end
     end
-
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,18 @@
+en:
+  rails_param:
+    type:
+      invalid: "%{param} is not a valid %{type}"
+    empty:
+      required_missing: "Parameter %{param_name} is required"
+      empty: "Parameter %{param_name} cannot be blank"
+    format:
+      format_not_string: "Parameter %{param_name} must be a string if using the format validation"
+      format_not_matching: "Parameter %{param_name} must match format %{value}"
+      format_not_values: "Parameter %{param_name} must be %{value}"
+    value:
+      not_in_range: "Parameter %{param_name} must be within %{value}"
+      not_less_than: "Parameter %{param_name} cannot be less than %{value}"
+      not_greater_than: "Parameter %{param_name} cannot be greater than %{value}"
+    length:
+      too_short: "Parameter %{param_name} cannot have length less than %{value}"
+      too_big: "Parameter %{param_name} cannot have length greater than %{value}"

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_param/param'
 require 'action_controller'
 
+I18n.load_path += Dir[File.expand_path("../../../locales/*.yml", __FILE__)]
+I18n.enforce_available_locales = false
+I18n.default_locale = :en
+
 class MyController < ActionController::Base
   include RailsParam::Param
 
@@ -175,7 +179,10 @@ describe RailsParam::Param do
 
         it "return InvalidParameterError if value not boolean" do
           allow(controller).to receive(:params).and_return({"foo" => "1111"})
-          expect { controller.param! :foo, :boolean }.to raise_error(RailsParam::Param::InvalidParameterError)
+          expect { controller.param! :foo, :boolean }.to raise_error(
+            RailsParam::Param::InvalidParameterError, 
+            I18n.t('rails_param.type.invalid', param: '1111', type: 'boolean')
+          )
         end
         it "set default boolean" do
           allow(controller).to receive(:params).and_return({})
@@ -186,7 +193,10 @@ describe RailsParam::Param do
 
       it "raises InvalidParameterError if the value is invalid" do
         allow(controller).to receive(:params).and_return({"foo" => "1984-01-32"})
-        expect { controller.param! :foo, Date }.to raise_error(RailsParam::Param::InvalidParameterError)
+        expect { controller.param! :foo, Date }.to raise_error(
+          RailsParam::Param::InvalidParameterError,
+          I18n.t('rails_param.type.invalid', param: '1984-01-32', type: 'Date')
+        )
       end
 
     end
@@ -334,7 +344,10 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({})
-          expect { controller.param! :price, Integer, required: true }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price is required")
+          expect { controller.param! :price, Integer, required: true }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.empty.required_missing', param_name: 'price')
+          )
         end
       end
 
@@ -346,7 +359,10 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => ""})
-          expect { controller.param! :price, String, blank: false }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price cannot be blank")
+          expect { controller.param! :price, String, blank: false }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.empty.empty', param_name: 'price')
+          )
         end
       end
 
@@ -358,7 +374,10 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => "50"})
-          expect { controller.param! :price, String, format: /[0-9]+\$/ }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price must match format #{/[0-9]+\$/}")
+          expect { controller.param! :price, String, format: /[0-9]+\$/ }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.format.format_not_matching', param_name: 'price', value: /[0-9]+\$/)
+          )
         end
       end
 
@@ -370,7 +389,10 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => "51"})
-          expect { controller.param! :price, String, is: "50" }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price must be 50")
+          expect { controller.param! :price, String, is: "50" }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.format.format_not_values', param_name: 'price', value: '50')
+          )
         end
       end
 
@@ -382,7 +404,10 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => "50"})
-          expect { controller.param! :price, Integer, min: 51 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price cannot be less than 51")
+          expect { controller.param! :price, Integer, min: 51 }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.value.not_less_than', param_name: 'price', value: '51')
+          )
         end
       end
 
@@ -394,7 +419,10 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"price" => "50"})
-          expect { controller.param! :price, Integer, max: 49 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price cannot be greater than 49")
+          expect { controller.param! :price, Integer, max: 49 }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.value.not_greater_than', param_name: 'price', value: '49')
+          )
         end
       end
 
@@ -406,7 +434,10 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"word" => "foo"})
-          expect { controller.param! :word, String, min_length: 4 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter word cannot have length less than 4")
+          expect { controller.param! :word, String, min_length: 4 }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.length.too_short', param_name: 'word', value: '4')
+          )
         end
       end
 
@@ -418,7 +449,10 @@ describe RailsParam::Param do
 
         it "raises" do
           allow(controller).to receive(:params).and_return({"word" => "foo"})
-          expect { controller.param! :word, String, max_length: 2 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter word cannot have length greater than 2")
+          expect { controller.param! :word, String, max_length: 2 }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.length.too_big', param_name: 'word', value: '2')
+          )
         end
       end
 
@@ -431,7 +465,10 @@ describe RailsParam::Param do
         end
 
         it "raises outside the range" do
-          expect { controller.param! :price, Integer, in: 51..100 }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price must be within 51..100")
+          expect { controller.param! :price, Integer, in: 51..100 }.to raise_error(
+            RailsParam::Param::InvalidParameterError,
+            I18n.t('rails_param.value.not_in_range', param_name: 'price', value: 51..100)
+          )
         end
       end
     end


### PR DESCRIPTION
This PR adds support to i18n of error messages.

In some cases, the exception message may be good enough to be dispatched to the final user (after handling the exception properly, of course). It is better to add i18n support to the gem than parsing each message and translating them to the user’s language.

The changes introduced by this PR should not affect the current behavior of the gem. It presents the translation if the respective files are included in the load path (e.g., `config/locales`), otherwise it falls back to the default message in English.

The file [`locales/en.yml`](https://github.com/nicolasblanco/rails_param/compare/master...gabrielres:master#diff-98e97cfa6efa32a2e18600bef3e4bc27) was added only for testing purposes and to be used as a model for other languages, and it is not used outside the gem.

This behaviour was inspired by the gem [`jsonapi-resources`](https://github.com/cerebris/jsonapi-resources).