### PR TITLE
Allow :boolean with value false to call transform proc

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -28,7 +28,7 @@ module RailsParam
         end
 
         # apply tranformation
-        if params[name] && options[:transform]
+        if params.has_key?(name) && options[:transform]
           params[name] = options[:transform].to_proc.call(params[name])
         end
 

--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -28,7 +28,7 @@ module RailsParam
         end
 
         # apply tranformation
-        if params.has_key?(name) && options[:transform]
+        if params.include?(name) && options[:transform]
           params[name] = options[:transform].to_proc.call(params[name])
         end
 

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -31,6 +31,12 @@ describe RailsParam::Param do
           controller.param! :word, String, transform: lambda { |n| n.downcase }
           expect(controller.params["word"]).to eql("foo")
         end
+
+        it "transforms falsey value" do
+          allow(controller).to receive(:params).and_return({"foo" => "0"})
+          controller.param! :foo, :boolean, transform: lambda { |n| n ? "bar" : "no bar" }
+          expect(controller.params["foo"]).to eql("no bar")
+        end
       end
     end
 


### PR DESCRIPTION
I'm not sure if this is the correct general behavior but I encountered a use-case where I needed to transform true/false into other symbols