### PR TITLE
Fix coerce Array or Hash into other types

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -92,6 +92,9 @@ module RailsParam
       begin
         return nil if param.nil?
         return param if (param.is_a?(type) rescue false)
+        if (param.is_a?(Array) && type != Array) || ((param.is_a?(Hash) || param.is_a?(ActionController::Parameters)) && type != Hash)
+          raise InvalidParameterError, "'#{param}' is not a valid #{type}"
+        end
         return param if (param.is_a?(ActionController::Parameters) && type == Hash rescue false)
         return Integer(param) if type == Integer
         return Float(param) if type == Float

--- a/spec/fixtures/controllers.rb
+++ b/spec/fixtures/controllers.rb
@@ -10,6 +10,7 @@ class FakeController < ActionController::Base
   def index
     param! :sort, String, in: %w(asc desc), default: "asc", transform: :downcase
     param! :page, Integer, default: 1
+    param! :tags, Array
 
     render text: "index"
   end

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -8,6 +8,21 @@ describe FakeController, type: :controller do
 
       expect(controller.params[:page]).to eql(666)
     end
+
+    it "raises InvalidParameterError if supplied an array instead of other type (prevent TypeError)" do
+      expect { get :index, page: ["a", "b", "c"] }.to raise_error(
+        RailsParam::Param::InvalidParameterError, %q('["a", "b", "c"]' is not a valid Integer))
+    end
+
+    it "raises InvalidParameterError if supplied an hash instead of other type (prevent TypeError)" do
+      expect { get :index, page: {"a" => "b", "c" => "d"} }.to raise_error(
+        RailsParam::Param::InvalidParameterError, %q('{"a"=>"b", "c"=>"d"}' is not a valid Integer))
+    end
+
+    it "raises InvalidParameterError if supplied an hash instead of an array (prevent NoMethodError)" do
+      expect { get :index, tags: {"a" => "b", "c" => "d"} }.to raise_error(
+        RailsParam::Param::InvalidParameterError, %q('{"a"=>"b", "c"=>"d"}' is not a valid Array))
+    end
   end
 
   describe "nested_hash" do


### PR DESCRIPTION
Prevent `TypeError` and `NoMethodError` if supplied  an Array or a Hash instead of other type.