### PR TITLE
Customize InvalidParameterError message

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ You may use the [rescue_from](http://api.rubyonrails.org/classes/ActiveSupport/R
 - `min` / `max`
 - `format`
 
+Customize exception message with option `:message`
+
+```ruby
+param! :q, String, required: true, message: "Query not specified"
+```
+
 ### Defaults and Transformations
 
 Passing a `default` option will provide a default value for a parameter if none is passed.  A `default` can defined as either a default or as a `Proc`:

--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -5,6 +5,11 @@ module RailsParam
 
     class InvalidParameterError < StandardError
       attr_accessor :param, :options
+
+      def message
+        return options[:message] if options.is_a?(Hash) && options.key?(:message)
+        super
+      end
     end
 
     class MockController

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -336,6 +336,11 @@ describe RailsParam::Param do
           allow(controller).to receive(:params).and_return({})
           expect { controller.param! :price, Integer, required: true }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price is required")
         end
+
+        it "raises custom message" do
+          allow(controller).to receive(:params).and_return({})
+          expect { controller.param! :price, Integer, required: true, message: "No price specified" }.to raise_error(RailsParam::Param::InvalidParameterError, "No price specified")
+        end
       end
 
       describe "blank parameter" do


### PR DESCRIPTION
Example:

```ruby
param! :q, String, required: true, message: "Query not specified"
```

When parameter `:q` is missed exception`InvalidParameterError` raised with provided message.