### PR TITLE
hashes: fix optional but nil value inputs

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -51,7 +51,7 @@ module RailsParam
                 params[name][i] = recurse({ i => element }, i, &block) # supply index as key unless value is hash
               end
             end
-          else
+          elsif params[name]
             recurse params[name], &block
           end
         end

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -324,6 +324,14 @@ describe RailsParam::Param do
         }.to raise_error(RailsParam::Param::InvalidParameterError)
       end
 
+      it 'handles a nil optional attribute' do
+        allow(controller).to receive(:params).and_return({'foo' => nil})
+        controller.param! :foo, Hash, require: false do |p|
+          p.param! :bar, String
+        end
+        expect(controller.params['foo']).to be_nil
+      end
+
       it 'raises exception if hash is not required but nested attributes are, and hash has missing attributes' do
         allow(controller).to receive(:params).and_return({'foo' => {'bar' => 1, 'baz' => nil}})
         expect {


### PR DESCRIPTION
hello,

without this fix, the attached spec raises:

```
NoMethodError:
       undefined method `include?' for nil:NilClass
     # ./lib/rails_param/param.rb:18:in `param!'
     # ./spec/rails_param/param_spec.rb:227:in `block (5 levels) in <top (required)>'
     # ./lib/rails_param/param.rb:88:in `recurse'
     # ./lib/rails_param/param.rb:48:in `param!'
     # ./spec/rails_param/param_spec.rb:226:in `block (4 levels) in <top (required)>'
```

It seems that right now, if the hash is optional but nil, rails_params will try to recurse into that hash anyways, promptly running into a nil value related error

I assume that it should be ok to pass an explicit nil value for an optional hash, and have rails_params accept the nil and let the transformed value be nil.