### PR TITLE
Auto deploy and Issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Basic Info
+
+* rails_param Version:
+* Ruby Version:
+* Rails Version:
+
+## Issue description
+Please provide a description of the issue you're experiencing.
+Please also provide the exception message/stacktrace or any other useful detail.
+
+## Steps to reproduce
+If possible, please provide the steps to reproduce the issue.
+
+## CHECKLIST (delete before creating the issue)
+* If you're not reporting a bug/issue, you can ignore this whole template.
+* Are you using the latest rails_param version? If not, please check the [Releases](https://github.com/nicolasblanco/rails_param/releases) page to see if the issue has already been fixed.
+* Provide the rails_param, Ruby and Rails Versions you're using while experiencing the issue in `Basic Info`.
+* Fill the `Issue description` and `Steps to Reproduce` sections.
+* Delete this checklist before posting the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+Link to related issues if any. (As `Fixes #XXX`)
+
+## Todos
+List any remaining work that needs to be done, i.e:
+- [ ] Tests
+- [ ] Documentation
+
+## Additional Notes
+Optional section

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: ruby
-
 rvm:
-  - "2.3.1"
-  - "2.2.5"
-
+  - 2.3.1
+  - 2.2.5
 gemfile:
   - ".gemfiles/Gemfile.rails-4.1.x"
   - ".gemfiles/Gemfile.rails-4.2.x"
-
 before_install:
   - gem install bundler --no-doc
+deploy:
+  provider: rubygems
+  api_key:
+    secure: GLQ4Kj7WO1ZRIxwfPzlUpYktczqQLfxqPhzMCkrI3N3kVvlLF7cusTGxX3ULmRXqXGmbu7XiSxplw/dCuhVghl51ivekxFF37SLP1zopNV4zw0er7oyGt6R4ZOY6db66jlJQwe3v+/ngrDwmLXUmYPKEtTXePoJgPurozdPbZ5s=
+  gem: rails_param
+  on:
+    tags: true
+    repo: nicolasblanco/rails_param
+    rvm: 2.3.1
+    gemfile: ".gemfiles/Gemfile.rails-4.2.x"


### PR DESCRIPTION
## Description
This PR is not feature-related, but instead adds the following to the repo:

* New releases (tags) are auto-deployed to Rubygems upon successful test run.
* There's now an Issue Template that users will see when opening an issue.
* There's now a Pull Request Template that users will see when submitting a PR.

## Additional Notes
Auto deployment key has been safely encrypted and deploy will trigger only when a new tag is pushed. This will automatically happen every time we create a new release here on GitHub.
Travis will also proceed with the release only if the tests are passing for Ruby 2.3.1 and Rails 4.2.
In case we added a more recent version of Ruby/Rails to the travis matrix, this condition should be updated as well.

@nicolasblanco please review this one and let me know if you have anything against it 😄 