### PR TITLE
Replace deprecated BigDecimal.new() with BigDecimal()

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -123,7 +123,7 @@ module RailsParam
         end
         if type == BigDecimal
           param = param.delete('$,').strip.to_f if param.is_a?(String)
-          return BigDecimal.new(param, (options[:precision] || DEFAULT_PRECISION))
+          return BigDecimal(param, (options[:precision] || DEFAULT_PRECISION))
         end
         return nil
       rescue ArgumentError


### PR DESCRIPTION
## Description
BigDecimal deprecated `.new` api. The suggested upgrade is `BigDecimal()`.

### Warning message
`warning: BigDecimal.new is deprecated; use BigDecimal() method instead`
