### PR TITLE
Support 'blank' for ActionController::Parameters

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -140,7 +140,7 @@ module RailsParam
             raise InvalidParameterError, "Parameter #{param_name} cannot be blank" if !value && case param
                                                                                     when String
                                                                                       !(/\S/ === param)
-                                                                                    when Array, Hash
+                                                                                    when Array, Hash, ActionController::Parameters
                                                                                       param.empty?
                                                                                     else
                                                                                       param.nil?

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -447,14 +447,44 @@ describe RailsParam::Param do
       end
 
       describe "blank parameter" do
-        it "succeeds" do
+        it "succeeds with not empty String" do
           allow(controller).to receive(:params).and_return({"price" => "50"})
           expect { controller.param! :price, String, blank: false }.to_not raise_error
         end
 
-        it "raises" do
+        it "raises with empty String" do
           allow(controller).to receive(:params).and_return({"price" => ""})
           expect { controller.param! :price, String, blank: false }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter price cannot be blank")
+        end
+
+        it "succeeds with not empty Hash" do
+          allow(controller).to receive(:params).and_return({"hash"=>{"price"=>"50"}})
+          expect { controller.param! :hash, Hash, blank: false }.to_not raise_error
+        end
+
+        it "raises with empty Hash" do
+          allow(controller).to receive(:params).and_return({"hash" => {}})
+          expect { controller.param! :hash, Hash, blank: false }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter hash cannot be blank")
+        end
+
+        it "succeeds with not empty Array" do
+          allow(controller).to receive(:params).and_return({"array"=>[50]})
+          expect { controller.param! :array, Array, blank: false }.to_not raise_error
+        end
+
+        it "raises with empty Array" do
+          allow(controller).to receive(:params).and_return({"array" => []})
+          expect { controller.param! :array, Array, blank: false }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter array cannot be blank")
+        end
+
+        it "succeeds with not empty ActiveController::Parameters" do
+          allow(controller).to receive(:params).and_return({"hash"=>ActionController::Parameters.new({"price"=>"50"})})
+          expect { controller.param! :hash, Hash, blank: false }.to_not raise_error
+        end
+
+        it "raises with empty ActiveController::Parameters" do
+          allow(controller).to receive(:params).and_return({"hash"=>ActionController::Parameters.new()})
+          expect { controller.param! :hash, Hash, blank: false }.to raise_error(RailsParam::Param::InvalidParameterError, "Parameter hash cannot be blank")
         end
       end
 


### PR DESCRIPTION
## Description

My use case:

```ruby
    # This is RESTful JSON API for updating operator resource (PATCH /operators/:operator_id)
    def update
      param! :operator_id, Integer, required: true
      param! :operator, Hash, required: true, blank: false # this 'blank: false' does not work because params[:operator] is an instance of ActionController::Parameters
      param! :update_mask, Array, required: true

      operator = Operator.find_by(id: params[:operator_id])
      # omitted
      return render json: operator
    end
```