### PR TITLE
Fixes `TypeError` being raised instead of `InvalidParameterError`

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -126,7 +126,7 @@ module RailsParam
           return BigDecimal(param, (options[:precision] || DEFAULT_PRECISION))
         end
         return nil
-      rescue ArgumentError
+      rescue ArgumentError, TypeError
         raise InvalidParameterError, "'#{param}' is not a valid #{type}"
       end
     end

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -89,6 +89,11 @@ describe RailsParam::Param do
           allow(controller).to receive(:params).and_return({ "foo" => "notInteger" })
           expect { controller.param! :foo, Integer }.to raise_error(RailsParam::Param::InvalidParameterError)
         end
+
+        it "will raise InvalidParameterError if the value is a boolean" do
+          allow(controller).to receive(:params).and_return({ "foo" => true })
+          expect { controller.param! :foo, Integer }.to raise_error(RailsParam::Param::InvalidParameterError)
+        end
       end
 
       describe "Float" do
@@ -100,6 +105,11 @@ describe RailsParam::Param do
 
         it "will raise InvalidParameterError if the value is not valid" do
           allow(controller).to receive(:params).and_return({ "foo" => "notFloat" })
+          expect { controller.param! :foo, Float }.to raise_error(RailsParam::Param::InvalidParameterError)
+        end
+
+        it "will raise InvalidParameterError if the value is a boolean" do
+          allow(controller).to receive(:params).and_return({ "foo" => true })
           expect { controller.param! :foo, Float }.to raise_error(RailsParam::Param::InvalidParameterError)
         end
       end
@@ -295,6 +305,7 @@ describe RailsParam::Param do
           allow(controller).to receive(:params).and_return({ "foo" => "1111" })
           expect { controller.param! :foo, :boolean }.to raise_error(RailsParam::Param::InvalidParameterError)
         end
+
         it "set default boolean" do
           allow(controller).to receive(:params).and_return({})
           controller.param! :foo, :boolean, default: false


### PR DESCRIPTION
## Description
Type initializers (e.g. `Integer()`) raise a `TypeError` when passed some types (e.g. Boolean), and `ArgumentError` for others (e.g. String).
This change adds TypeError to the list of rescued exceptions that get re-raised as `InvalidParameterError`.
Fixes #48.