### PR TITLE
Fixes "undefined method `split`" being raised instead of `InvalidParameterError`

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -100,7 +100,7 @@ module RailsParam
         return nil if param.nil?
         return param if (param.is_a?(type) rescue false)
         if (param.is_a?(Array) && type != Array) || ((param.is_a?(Hash) || param.is_a?(ActionController::Parameters)) && type != Hash)
-          raise InvalidParameterError, "'#{param}' is not a valid #{type}"
+          raise ArgumentError
         end
         return param if (param.is_a?(ActionController::Parameters) && type == Hash rescue false)
         return Integer(param) if type == Integer
@@ -113,6 +113,7 @@ module RailsParam
             return type.parse(param)
           end
         end
+        raise ArgumentError if (type == Array || type == Hash) && !param.respond_to?(:split)
         return Array(param.split(options[:delimiter] || ",")) if type == Array
         return Hash[param.split(options[:delimiter] || ",").map { |c| c.split(options[:separator] || ":") }] if type == Hash
         if type == TrueClass || type == FalseClass || type == :boolean

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -120,6 +120,11 @@ describe RailsParam::Param do
           controller.param! :foo, Array
           expect(controller.params["foo"]).to eql(["2", "3", "4", "5"])
         end
+
+        it "will raise InvalidParameterError if the value is a boolean" do
+          allow(controller).to receive(:params).and_return({ "foo" => true })
+          expect { controller.param! :foo, Array }.to raise_error(RailsParam::Param::InvalidParameterError)
+        end
       end
 
       describe "Hash" do
@@ -127,6 +132,11 @@ describe RailsParam::Param do
           allow(controller).to receive(:params).and_return({ "foo" => "key1:foo,key2:bar" })
           controller.param! :foo, Hash
           expect(controller.params["foo"]).to eql({ "key1" => "foo", "key2" => "bar" })
+        end
+
+        it "will raise InvalidParameterError if the value is a boolean" do
+          allow(controller).to receive(:params).and_return({ "foo" => true })
+          expect { controller.param! :foo, Hash }.to raise_error(RailsParam::Param::InvalidParameterError)
         end
       end
 


### PR DESCRIPTION
## Description
Adds safety check to ensure that parameter responds to `split` (e.g. is a String) before attempting type coercion to Array or Hash.
Fixes #49.