### PR TITLE
Add GitHub Action to auto-publish on Rubygems after releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Publish to Rubygems
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Ruby 2.7
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.x
+
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build rails_param.gemspec
+          gem push rails_param-*.gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}


### PR DESCRIPTION
## Description

This PR introduces a `publish` GitHub Action responsible to automatically publish a new version of the gem any time a "release" is created on GitHub.
We use this procedure in Faraday to allow all collaborators to publish new versions of the gem without requiring Rubygems access.

## Additional Notes

I've created a `0.x` branch from the last release tag and used that as base branch for this PR. This is because we're preparing v1.0 release, but we may still need to back-port bug fixes, so in that scenario we'll be able to use that branch.
I'll pull this change into master after it's merged.

cc @nicolasblanco @ifellinaholeonce 
I'm tagging you on this PR for visibility, but I won't be waiting for a code review to merge it because I'd like to test if it works and there are no actual code changes 😄. Hope that is fine!
