### PR TITLE
Add test case for nested array behavior

### DIFF
--- a/spec/fixtures/controllers.rb
+++ b/spec/fixtures/controllers.rb
@@ -32,4 +32,13 @@ class FakeController < ActionController::Base
     render plain: :book
   end
 
+  def nested_array
+    param! :filter, Hash, default: {} do |f|
+      f.param! :state, Array do |s, idx|
+        s.param! idx, String, required: true
+      end
+    end
+
+    render plain: :nested_array
+  end
 end

--- a/spec/fixtures/fake_rails_application.rb
+++ b/spec/fixtures/fake_rails_application.rb
@@ -15,7 +15,8 @@ module Rails
         get '/fake/new' => "fake#new"
         get '/fakes' => "fake#index"
         get '/fake/(:id)' => "fake#show"
-          get '/fake/edit' => "fake#edit"
+        get '/fake/edit' => "fake#edit"
+        get '/fake/nested_array' => "fake#nested_array"
       end
       @routes
     end

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -104,4 +104,16 @@ describe FakeController, type: :controller do
       expect(controller.params[:sort]).to eql("asc")
     end
   end
+
+  describe "nested_array" do
+    it "responds with a 400 when the nested array is not supplied properly" do
+      params = {
+        'filter' => 'state'
+      }
+
+      expect { get :nested_array, **prepare_params(params) }.to raise_error do |error|
+        expect(error).to be_a(RailsParam::InvalidParameterError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

Ensures that passing a string to a controller that expects an array of strings raises an invalid parameter error.

This behavior was fixed in the refactor, but not yet fixed in 0.11.2. I figured adding an explicit test case might not be a bad thing :sunglasses: 

## Todos
None

## Additional Notes
None
