### PR TITLE
Drop Support for EOL Ruby and Rails versions

### DIFF
--- a/.gemfiles/rails-5.0.x.gemfile
+++ b/.gemfiles/rails-5.0.x.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org" do
-  gem 'rails', '~> 5.0.0'
-end
-
-eval_gemfile '../Gemfile'

--- a/.gemfiles/rails-5.1.x.gemfile
+++ b/.gemfiles/rails-5.1.x.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org" do
-  gem 'rails', '~> 5.1.0'
-end
-
-eval_gemfile '../Gemfile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
+        ruby: ['2.6', '2.7', '3.0' ]
         gemfile:
-          - .gemfiles/rails-5.0.x.gemfile
-          - .gemfiles/rails-5.1.x.gemfile
           - .gemfiles/rails-5.2.x.gemfile
           - .gemfiles/rails-6.0.x.gemfile
           - .gemfiles/rails-6.1.x.gemfile
-        exclude:
-          - ruby: '2.4'
-            gemfile: .gemfiles/rails-6.0.x.gemfile
-          - ruby: '2.4'
-            gemfile: .gemfiles/rails-6.1.x.gemfile
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Following up on #65 and towards 1.0, this PR removes support for the EOL'd versions of Ruby and Rails that were in the test matrix:

Ruby:
2.4
2.5

Rails:
5.0
5.1

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests
- [ ] Documentation
