### PR TITLE
Fix required parameter regression

### DIFF
--- a/lib/rails_param/validator/required.rb
+++ b/lib/rails_param/validator/required.rb
@@ -4,7 +4,7 @@ module RailsParam
       private
 
       def valid_value?
-        value.present? && options[:required]
+        value.present? || !options[:required]
       end
 
       def error_message

--- a/spec/rails_param/validator/required_spec.rb
+++ b/spec/rails_param/validator/required_spec.rb
@@ -35,5 +35,15 @@ describe RailsParam::Validator::Required do
         it_behaves_like "raises InvalidParameterError"
       end
     end
+
+    context "parameter is not required" do
+      let(:options) { { required: false } }
+
+      context "value is not present" do
+        let(:value) { nil }
+
+        it_behaves_like "does not raise error"
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

The 1.0 release introduced a regression where parameters that were not
required and had a default that isn't `#present?` would cause an invalid
parameter error to be raised. This commit fixes the logic in the
required validator and adds a spec so it doesn't break in the future :)

Here's an example of where this regression can come into play:

```ruby
param! :sort, Hash, required: false, default: {} do |s|
  s.param! :order, String, in: [ "asc", "desc" ]
end
```

If no `sort` parameter is provided in the request, it defaults to `{}`, then the required validator ends up raising an error because `{}` is not present, nor is the parameter required.