### PR TITLE
Fix array coercion regression

### DIFF
--- a/lib/rails_param/coercion/array_param.rb
+++ b/lib/rails_param/coercion/array_param.rb
@@ -2,6 +2,7 @@ module RailsParam
   class Coercion
     class ArrayParam < VirtualParam
       def coerce
+        return [] if param.nil?
         return param if param.is_a?(Array)
 
         Array(param.split(options[:delimiter] || ","))
@@ -11,7 +12,10 @@ module RailsParam
 
       def argument_validation
         raise ArgumentError unless type == Array
-        raise ArgumentError unless param.respond_to?(:split)
+
+        return if param.nil? || param.respond_to?(:split)
+
+        raise ArgumentError
       end
     end
   end

--- a/lib/rails_param/param_evaluator.rb
+++ b/lib/rails_param/param_evaluator.rb
@@ -51,6 +51,13 @@ module RailsParam
 
     def recurse_on_parameter(parameter, &block)
       if parameter.type == Array
+        unless parameter.value.respond_to?(:each_with_index)
+          raise(
+            InvalidParameterError,
+            "'#{parameter.value}' is not a valid #{parameter.type}"
+          )
+        end
+
         parameter.value.each_with_index do |element, i|
           if element.is_a?(Hash) || element.is_a?(ActionController::Parameters)
             recurse element, &block

--- a/spec/rails_param/coercion/array_param_spec.rb
+++ b/spec/rails_param/coercion/array_param_spec.rb
@@ -71,5 +71,13 @@ describe RailsParam::Coercion::ArrayParam do
 
       it_behaves_like "returns an array"
     end
+
+    context "param is nil" do
+      let(:param) { nil }
+
+      it "returns an empty array" do
+        expect(subject.coerce).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

The 1.0 release introduced a regression in Array coercion. Previously `nil` would be coerced into an empty array but now it raises an invalid parameter error.

Ironically the regression fix re-introduced a bug that I added a test case for in #70 so I had to add a little extra logic to fix that as well.

