### PR TITLE
Fix regression in required validator

### DIFF
--- a/lib/rails_param/validator/required.rb
+++ b/lib/rails_param/validator/required.rb
@@ -4,7 +4,7 @@ module RailsParam
       private
 
       def valid_value?
-        value.present? || !options[:required]
+        !(value.nil? && options[:required])
       end
 
       def error_message

--- a/spec/rails_param/validator/required_spec.rb
+++ b/spec/rails_param/validator/required_spec.rb
@@ -22,6 +22,13 @@ describe RailsParam::Validator::Required do
       it_behaves_like "does not raise error"
     end
 
+    context "value given is not nil but is also not present" do
+      let(:type) { Hash }
+      let(:value) { {} }
+
+      it_behaves_like "does not raise error"
+    end
+
     context "value is not present" do
       let(:error_message) { "Parameter foo is required" }
       let(:value)         { nil }


### PR DESCRIPTION
## Description

The 1.0 release introduced a behaviour change in required values. Prior
to 1.0, empty objects (e.g. `{}`) were acceptable values for required
parameters. This commit re-introduces that behaviour.