### PR TITLE
Fix optional array behaviour

### DIFF
--- a/lib/rails_param/param_evaluator.rb
+++ b/lib/rails_param/param_evaluator.rb
@@ -10,12 +10,10 @@ module RailsParam
       name = name.is_a?(Integer)? name : name.to_s
       return unless params.include?(name) || check_param_presence?(options[:default]) || options[:required]
 
-      # coerce value
-      coerced_value = coerce(
-        params[name],
-        type,
-        options
-      )
+      # coerce value (but only if a value was provided)
+      coerced_value = params.include?(name) ?
+        coerce(params[name], type, options) : nil
+
       parameter = RailsParam::Parameter.new(
         name: name,
         value: coerced_value,

--- a/spec/fixtures/controllers.rb
+++ b/spec/fixtures/controllers.rb
@@ -41,4 +41,10 @@ class FakeController < ActionController::Base
 
     render plain: :nested_array
   end
+
+  def optional_array
+    param! :my_array, Array, default: []
+
+    render plain: :optional_array
+  end
 end

--- a/spec/fixtures/fake_rails_application.rb
+++ b/spec/fixtures/fake_rails_application.rb
@@ -17,6 +17,8 @@ module Rails
         get '/fake/(:id)' => "fake#show"
         get '/fake/edit' => "fake#edit"
         get '/fake/nested_array' => "fake#nested_array"
+        # POST required to send `null` without it becoming ''.
+        post '/fake/optional_array' => "fake#optional_array"
       end
       @routes
     end

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -116,4 +116,26 @@ describe FakeController, type: :controller do
       end
     end
   end
+
+  describe "optional_array" do
+    # If we don't specify a content type that can accept `null` as a value,
+    # rails may attempt to coerce nil values into empty strings.
+    # See here:
+    #   https://github.com/rails/rails-controller-testing/issues/33
+    before { request.headers['Content-Type'] = 'application/json' }
+
+    it "responds with a 200 when the optional array is not provided" do
+      post :optional_array, **prepare_params({})
+
+      expect(response.status).to eq(200)
+    end
+
+    it "raises an invalid parameter error when nil is explicitly provided" do
+      params = { my_array: nil }
+
+      expect { post :optional_array, **prepare_params(params) }.to raise_error do |error|
+        expect(error).to be_a(RailsParam::InvalidParameterError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

This fix is an alternative to #76. It allows arrays with a default value
to not raise an invalid parameter error when a value is not explicitly
sent in the request. It also raises an invalid parameter error when an
array parameter is explicitly sent up with a `null` value.

## Additional Notes

This version of the fix was inspired by the comments in #76.
