### PR TITLE
String without delimiter should not be considered a valid hash

### DIFF
--- a/lib/rails_param/coercion/hash_param.rb
+++ b/lib/rails_param/coercion/hash_param.rb
@@ -2,10 +2,14 @@ module RailsParam
   class Coercion
     class HashParam < VirtualParam
       def coerce
+        delimiter = options[:delimiter] || ","
+        separator = options[:separator] || ":"
+
         return param if param.is_a?(ActionController::Parameters)
         raise ArgumentError unless param.respond_to?(:split)
+        raise ArgumentError unless param.include?(separator)
 
-        Hash[param.split(options[:delimiter] || ",").map { |c| c.split(options[:separator] || ":") }]
+        Hash[param.split(delimiter).map { |c| c.split(separator) }]
       end
 
       private

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -106,14 +106,9 @@ describe FakeController, type: :controller do
   end
 
   describe "nested_array" do
-    it "responds with a 400 when the nested array is not supplied properly" do
-      params = {
-        'filter' => 'state'
-      }
-
-      expect { get :nested_array, **prepare_params(params) }.to raise_error do |error|
-        expect(error).to be_a(RailsParam::InvalidParameterError)
-      end
+    it "responds with a 400 when you supply a string instead of a hash" do
+      expect { get :nested_array, **prepare_params({ filter: 'a string' }) }
+        .to raise_error(RailsParam::InvalidParameterError)
     end
   end
 

--- a/spec/rails_param/coercion/hash_param_spec.rb
+++ b/spec/rails_param/coercion/hash_param_spec.rb
@@ -24,13 +24,12 @@ describe RailsParam::Coercion::HashParam do
   end
 
   describe ".new" do
-    let(:param) { "foo,bar" }
+    let(:param) { "foo1:bar1,foo2:bar2" }
 
     context "type is Hash" do
       let(:type) { Hash }
 
       context "param responds to #split" do
-
         it_behaves_like "does not raise an error"
       end
     end
@@ -60,11 +59,20 @@ describe RailsParam::Coercion::HashParam do
       it_behaves_like "returns a hash"
     end
 
-    context "options delimiter provided" do
+    context "options separator provided" do
       let(:options) { {separator: "!"} }
       let(:param)   { "foo!bar,fizz!buzz" }
 
       it_behaves_like "returns a hash"
+    end
+
+    context "param is not separable" do
+      let(:param) { "foo,bar" }
+
+
+      it "raises an ArgumentError" do
+        expect { subject.coerce }.to raise_error ArgumentError
+      end
     end
 
     context "param does not respond to split" do


### PR DESCRIPTION
## Description

Fixes another bug that prevents bug from #80 from being fixed