### PR TITLE
Keep only necessary rails gem dependencies

### DIFF
--- a/.gemfiles/rails-5.2.x.gemfile
+++ b/.gemfiles/rails-5.2.x.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org" do
-  gem 'rails', '~> 5.2.0'
+  gem 'actionpack', '~> 5.2.0'
+  gem 'activesupport', '~> 5.2.0'
 end
 
 eval_gemfile '../Gemfile'

--- a/.gemfiles/rails-6.0.x.gemfile
+++ b/.gemfiles/rails-6.0.x.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org" do
-  gem 'rails', '~> 6.0.0'
+  gem 'actionpack', '~> 6.0.0'
+  gem 'activesupport', '~> 6.0.0'
 end
 
 eval_gemfile '../Gemfile'

--- a/.gemfiles/rails-6.1.x.gemfile
+++ b/.gemfiles/rails-6.1.x.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org" do
-  gem 'rails', '~> 6.1.0'
+  gem 'actionpack', '~> 6.1.0'
+  gem 'activesupport', '~> 6.1.0'
 end
 
 eval_gemfile '../Gemfile'

--- a/rails_param.gemspec
+++ b/rails_param.gemspec
@@ -26,8 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'rspec-rails', '~> 3.4'
-  s.add_development_dependency 'actionpack', '>= 3.2.0'
-  s.add_development_dependency 'activesupport', '>= 3.2.0'
 
-  s.add_runtime_dependency 'rails', '>= 3.2.0'
+  s.add_dependency 'actionpack', '>= 3.2.0'
+  s.add_dependency 'activesupport', '>= 3.2.0'
 end


### PR DESCRIPTION
## Description
As discussed in https://github.com/nicolasblanco/rails_param/issues/87 it makes sense to keep only necessary rails dependencies. It will allow to use this gem without the whole rails suite

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests
- [ ] Documentation

## Additional Notes
Optional section
