### PR TITLE
Update actions/checkout to v3 and switch to ruby/setup-ruby to eliminate warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         rails: ['~> 5.2', '~> 6.0', '~> 6.1', '~> 7.0']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.7
 
       - name: Publish to RubyGems
         run: |


### PR DESCRIPTION
## Description

Use of a v2 checkout action leads to Node 12 warnings in the CI runs.  Upgrading to v3 eliminates those warnings.

The actions/setup-ruby is no longer supported.  Switch to ruby/setup-ruby and update the version string syntax to match.
