### PR TITLE
Automatically permit validated params

### DIFF
--- a/lib/rails_param/param.rb
+++ b/lib/rails_param/param.rb
@@ -1,5 +1,14 @@
 module RailsParam
+  attr_accessor :rails_params
+
   def param!(name, type, options = {}, &block)
-    ParamEvaluator.new(params).param!(name, type, options, &block)
+    hierarchy = ParamEvaluator.new(params).param!(name, type, options, &block)
+
+    @rails_params =
+      if params.is_a?(ActionController::Parameters)
+        params.permit(hierarchy)
+      else
+        params
+      end
   end
 end

--- a/lib/rails_param/param_evaluator.rb
+++ b/lib/rails_param/param_evaluator.rb
@@ -1,8 +1,5 @@
 module RailsParam
   class ParamEvaluator
-
-    CONTEXT_SEPARATOR = '.'.freeze
-
     attr_accessor :params
 
     def initialize(params, context = nil, hierarchy = nil)
@@ -71,7 +68,7 @@ module RailsParam
       # set params value
       params[name] = parameter.value
 
-      @hierarchy
+      [@hierarchy, parameter.value]
     end
 
     private
@@ -84,7 +81,8 @@ module RailsParam
           if element.is_a?(Hash) || element.is_a?(ActionController::Parameters)
             recurse element, "#{parameter.name}[#{i}]", &block
           else
-            parameter.value[i] = recurse({ i => element }, parameter.name, i, &block) # supply index as key unless value is hash
+            _, value = recurse({ i => element }, parameter.name, i, &block) # supply index as key unless value is hash
+            parameter.value[i] = value
           end
         end
       else

--- a/lib/rails_param/param_evaluator.rb
+++ b/lib/rails_param/param_evaluator.rb
@@ -36,8 +36,9 @@ module RailsParam
 
       update_hierarchy(type, name)
 
-      recurse_result = recurse_on_parameter(parameter, &block) if block_given?
-      @hierarchy[@child_key] = recurse_result
+      if block_given?
+        @hierarchy[@child_key] = recurse_on_parameter(parameter, &block)
+      end
 
       # apply transformation
       parameter.transform if options[:transform]

--- a/lib/rails_param/param_evaluator.rb
+++ b/lib/rails_param/param_evaluator.rb
@@ -8,14 +8,14 @@ module RailsParam
     def initialize(params, context = nil, hierarchy = nil)
       @params = params
       @context = context
-      @hierarchy = hierarchy || Hash.new { |h, k| h[k] = h.dup.clear }
+      @hierarchy = hierarchy || Hash.new { |hash, key| hash[key] = {} }
     end
 
     def param!(name, type, options = {}, &block)
-      name = name.is_a?(Integer)? name : name.to_s
+      @name = name = name.is_a?(Integer)? name : name.to_s
       return unless params.include?(name) || check_param_presence?(options[:default]) || options[:required]
 
-      parameter_name = @context ? "#{@context}#{CONTEXT_SEPARATOR}#{name}" : name
+      parameter_name = @context ? "#{@context}[#{name}]" : name
       coerced_value = coerce(parameter_name, params[name], type, options)
 
       parameter = RailsParam::Parameter.new(
@@ -37,21 +37,30 @@ module RailsParam
         )
       end
 
-      path_keys = @context.split(CONTEXT_SEPARATOR) if @context
-      if @context.nil? && (type == Hash || type == Array)
-        # root
-        @hierarchy[name] = {}
-      elsif @context && (type == Hash || type == Array)
-        # is an intermediate child
-        @hierarchy.dig(*path_keys)[name] = type.new
-      elsif @context && path_keys.present?
-        # is a leaf
-        leaf = @hierarchy.dig(*(path_keys[...-1]))
-        leaf[path_keys.last] = [] if leaf[path_keys.last].is_a?(Hash)
-        leaf[path_keys.last] << name
+      if @hierarchy.nil?
+        @hierarchy =
+          if type == Array && !block_given?
+            []
+          elsif type == Hash || type == Array
+            {}
+          end
+      else
+        if type == Hash || type == Array
+          @hierarchy[name] =
+          if type == Array && !block_given?
+            []
+          elsif type == Hash || type == Array
+            {}
+          end
+        elsif @hierarchy.is_a?(Array)
+          @hierarchy << name.to_sym
+        else
+          @hierarchy = [] if @hierarchy.is_a?(Hash)
+          @hierarchy << name
+        end
       end
 
-      recurse_on_parameter(parameter, &block) if block_given?
+      @hierarchy[name] = recurse_on_parameter(parameter, &block) if block_given?
 
       # apply transformation
       parameter.transform if options[:transform]
@@ -62,7 +71,7 @@ module RailsParam
       # set params value
       params[name] = parameter.value
 
-      @hierarchy if @context.nil?
+      @hierarchy
     end
 
     private
@@ -73,7 +82,7 @@ module RailsParam
       if parameter.type == Array
         parameter.value.each_with_index do |element, i|
           if element.is_a?(Hash) || element.is_a?(ActionController::Parameters)
-            recurse element, "#{parameter.name}#{CONTEXT_SEPARATOR}#{i}", &block
+            recurse element, "#{parameter.name}[#{i}]", &block
           else
             parameter.value[i] = recurse({ i => element }, parameter.name, i, &block) # supply index as key unless value is hash
           end
@@ -86,7 +95,7 @@ module RailsParam
     def recurse(element, context, index = nil)
       raise InvalidParameterError, 'no block given' unless block_given?
 
-      yield(ParamEvaluator.new(element, context, @hierarchy), index)
+      yield(ParamEvaluator.new(element, context, @hierarchy[@name]), index)
     end
 
     def check_param_presence? param

--- a/lib/rails_param/param_evaluator.rb
+++ b/lib/rails_param/param_evaluator.rb
@@ -5,7 +5,7 @@ module RailsParam
     def initialize(params, context = nil, hierarchy = nil)
       @params = params
       @context = context
-      @hierarchy = hierarchy || Hash.new { |hash, key| hash[key] = {} }
+      @hierarchy = hierarchy || {}
     end
 
     def param!(name, type, options = {}, &block)
@@ -34,27 +34,18 @@ module RailsParam
         )
       end
 
-      if @hierarchy.nil?
-        @hierarchy =
+      if type == Hash || type == Array
+        @hierarchy[name] =
           if type == Array && !block_given?
             []
           elsif type == Hash || type == Array
             {}
           end
+      elsif @hierarchy.is_a?(Array)
+        @hierarchy << name.to_sym
       else
-        if type == Hash || type == Array
-          @hierarchy[name] =
-          if type == Array && !block_given?
-            []
-          elsif type == Hash || type == Array
-            {}
-          end
-        elsif @hierarchy.is_a?(Array)
-          @hierarchy << name.to_sym
-        else
-          @hierarchy = [] if @hierarchy.is_a?(Hash)
-          @hierarchy << name
-        end
+        @hierarchy = [] if @hierarchy.is_a?(Hash)
+        @hierarchy << name
       end
 
       @hierarchy[name] = recurse_on_parameter(parameter, &block) if block_given?

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -804,5 +804,52 @@ describe RailsParam do
         end
       end
     end
+
+    describe "permitting" do
+      it 'permits all nested attributes' do
+        input_params = {
+          mimmo: {
+            'foo' => { 'bar' => BigDecimal(1), 'baz' => 2 },
+            'arr' => [1, 2, 3]
+          }
+        }
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(input_params))
+        safe_params = controller.param! :mimmo, Hash do |mimmo|
+          mimmo.param! :foo, Hash do |p|
+            p.param! :bar, BigDecimal
+            p.param! :baz, Float
+          end
+          mimmo.param! :arr, Array
+        end
+
+        expect(safe_params).to be_permitted
+        expect(safe_params.to_h.with_indifferent_access).to eq({
+          'mimmo' => {
+            'foo' => { 'bar' => BigDecimal(1), 'baz' => 2 },
+            'arr' => [1, 2, 3]
+          }
+        })
+      end
+
+      it 'permits only specified attributes' do
+        input_params = {
+          mimmo: {
+            'foo' => { 'bar' => 1, 'baz' => 2 },
+            'arr' => [1, 2, 3]
+          }
+        }
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(input_params))
+        safe_params = controller.param! :mimmo, Hash do |mimmo|
+          mimmo.param! :arr, Array
+        end
+
+        expect(safe_params).to be_permitted
+        expect(safe_params.to_h.with_indifferent_access).to eq({
+          'mimmo' => {
+            'arr' => [1, 2, 3]
+          }
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
fixes #99 
As I explained in https://github.com/nicolasblanco/rails_param/issues/99, it would be really useful to automatically permit the validated params. I'm already sharing this PR to collect feedbacks

The idea is to create a hierarchy structure, similar to `params` that is passed from the upper element to its child and so on. Each child update the `hierarchy` element it received and since it is passed by reference the hierarchy gets updated step by step, at the end we have the full structure.

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Add configuration to enable/disable params permitting
- [ ] Investigate edge cases
- [ ] Documentation

## Additional Notes
Let me know what's your idea to make this configurable, I was thinking of an initializer to enable it globally, something like
```ruby
RailsParam.configure do |config|
    config.permit_params = true
end
```
