### PR TITLE
Use i18n locale in error messages so users can customize the error me…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'i18n'
 gem 'pry'
 gem 'simplecov', require: false, group: :test
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rails_param
+
 _Parameter Validation & Type Coercion for Rails_
 
 [![Gem Version](https://badge.fury.io/rb/rails_param.svg)](https://rubygems.org/gems/rails_param)
@@ -34,13 +35,13 @@ Find a list of breaking changes in [UPGRADING](UPGRADING.md).
 
 As usual, in your Gemfile...
 
-``` ruby
+```ruby
   gem 'rails_param'
 ```
 
 ## Example
 
-``` ruby
+```ruby
   # GET /search?q=example
   # GET /search?q=example&categories=news
   # GET /search?q=example&sort=created_at&order=ASC
@@ -58,7 +59,7 @@ end
 
 ### Parameter Types
 
-By declaring parameter types, incoming parameters will automatically be transformed into an object of that type. For instance, if a param is `:boolean`, values of `'1'`, `'true'`, `'t'`, `'yes'`, and `'y'` will be automatically transformed into `true`.  `BigDecimal` defaults to a precision of 14, but this can but changed by passing in the optional `precision:` argument. Any `$` and `,` are automatically stripped when converting to `BigDecimal`.
+By declaring parameter types, incoming parameters will automatically be transformed into an object of that type. For instance, if a param is `:boolean`, values of `'1'`, `'true'`, `'t'`, `'yes'`, and `'y'` will be automatically transformed into `true`. `BigDecimal` defaults to a precision of 14, but this can but changed by passing in the optional `precision:` argument. Any `$` and `,` are automatically stripped when converting to `BigDecimal`.
 
 - `String`
 - `Integer`
@@ -90,7 +91,7 @@ param! :q, String, required: true, message: "Query not specified"
 
 ### Defaults and Transformations
 
-Passing a `default` option will provide a default value for a parameter if none is passed.  A `default` can defined as either a default or as a `Proc`:
+Passing a `default` option will provide a default value for a parameter if none is passed. A `default` can defined as either a default or as a `Proc`:
 
 ```ruby
 param! :attribution, String, default: "©"
@@ -142,12 +143,72 @@ param! :books_array, Array, required: true  do |b|
 end
 ```
 
+## Internationalization (i18n) Support 🌍
+
+RailsParam gem supports internationalization (i18n) for its error messages. This allows you to translate the error messages into different languages or customize them as per your requirements.
+
+The gem comes with a default set of error messages in English ('en') to get you started. You can find the locale file in the `lib/i18n/locales` directory of this GitHub repository. 📁
+
+You don't need to create the 'en' locale file if you don't want to override the default error messages.
+
+However, you can add your own translations for other languages by following these steps:
+
+- Ensure that you have the i18n gem installed in your Rails application. If not, add it to your Gemfile and run `bundle install`. 💎
+
+- Create or update the translation file for the desired locale. 🌐
+
+```yaml
+fr:
+  rails_param:
+    errors:
+      invalid_type: "'%{value}' n'est pas un %{type} valide"
+      required: "Le paramètre %{name} est requis"
+      no_block: "aucun bloc donné"
+      blank: "Le paramètre %{name} ne peut pas être vide"
+      invalid_string_or_time: "Le paramètre %{name} doit être une chaîne de caractères s'il utilise la validation du format"
+      invalid_string_format: "Le paramètre %{name} doit correspondre au format %{format_pattern}"
+      in: "Le paramètre %{name} doit être compris entre %{in}"
+      is: "Le paramètre %{name} doit être %{is}"
+      max_length: "Le paramètre %{name} ne peut pas avoir une longueur supérieure à %{max_length}"
+      max: "Le paramètre %{name} ne peut pas être supérieur à %{max}"
+      min_length: "Le paramètre %{name} ne peut pas avoir une longueur inférieure à %{min_length}"
+      min: "Le paramètre %{name} ne peut pas être inférieur à %{min}"
+```
+
+- When an error occurs, RailsParam will automatically look up the translation key based on the current locale and provide the translated error message. 🔄
+
+### Variables in the Locale YAML File 📝
+
+The locale YAML file for RailsParam gem provides the following variables that can be used to create dynamic error messages:
+
+- **`name`**: Represents the name of the parameter being validated. This variable allows you to include the parameter's name dynamically in the error message. For example, if the parameter name is "username," you can use `%{name}` in the error message to reference the parameter name.
+
+- **`value`**: Represents the value of the parameter that was passed by the user. This variable allows you to include the actual value in the error message. For example, if the user passed the value "john.doe" for the parameter, you can use `%{value}` in the error message to reference the actual value.
+
+- **`type`:** Represents the expected type of the parameter in the validation. This variable allows you to include the expected type dynamically in the error message. For example, if the expected type is "string," you can use `%{type}` in the error message to reference the expected type.
+
+- **`format_pattern`**: Represents the expected format pattern in format validation. This variable allows you to include the expected format pattern dynamically in the error message. For example, if the expected format pattern is "YYYY-MM-DD," you can use `%{format_pattern}` in the error message to reference the expected format pattern.
+
+- **`in`**: Represents the expected set of values in the 'in' validation. This variable allows you to include the expected set of values dynamically in the error message. For example, if the expected set of values is ["red", "green", "blue"], you can use `%{in}` in the error message to reference the expected set of values.
+
+- **`is`**: Represents a specific value that the parameter should be equal to in the validation. This variable allows you to include the expected value dynamically in the error message. For example, if the parameter should be equal to 10, you can use `%{is}` in the error message to reference the expected value.
+
+- **`max_length`**: Represents the maximum length allowed for the parameter. This variable allows you to include the maximum length dynamically in the error message. For example, if the maximum length is 50, you can use `%{max_length}` in the error message to reference the maximum length.
+
+- **`max`**: Represents the maximum value allowed for the parameter. This variable allows you to include the maximum value dynamically in the error message. For example, if the maximum value is 100, you can use `%{max}` in the error message to reference the maximum value.
+
+- **`min_length`**: Represents the minimum length required for the parameter. This variable allows you to include the minimum length dynamically in the error message. For example, if the minimum length is 5, you can use `%{min_length}` in the error message to reference the minimum length.
+
+- **`min`**: Represents the minimum value required for the parameter. This variable allows you to include the minimum value dynamically in the error message. For example, if the minimum value is 0, you can use `%{min}` in the error message to reference the minimum value.
+
+If you want to contribute translations for additional languages or customize the existing translations, please refer to the i18n gem documentation for more details on how to manage translation files.
+
 ## Thank you
 
 Many thanks to:
 
-* [Mattt Thompson (@mattt)](https://twitter.com/mattt)
-* [Vincent Ollivier (@vinc686)](https://twitter.com/vinc686)
+- [Mattt Thompson (@mattt)](https://twitter.com/mattt)
+- [Vincent Ollivier (@vinc686)](https://twitter.com/vinc686)
 
 ## Contact
 

--- a/lib/i18n/locales/en.yml
+++ b/lib/i18n/locales/en.yml
@@ -1,0 +1,15 @@
+en:
+  rails_param:
+    errors:
+      invalid_type: "'%{value}' is not a valid %{type}"
+      required: "Parameter %{name} is required"
+      no_block: "no block given"
+      blank: "Parameter %{name} cannot be blank"
+      invalid_string_or_time: "Parameter %{name} must be a string if using the format validation"
+      invalid_string_format: "Parameter %{name} must match format %{format_pattern}"
+      in: "Parameter %{name} must be within %{in}"
+      is: "Parameter %{name} must be %{is}"
+      max_length: "Parameter %{name} cannot have length greater than %{max_length}"
+      max: "Parameter %{name} cannot be greater than %{max}"
+      min_length: "Parameter %{name} cannot have length less than %{min_length}"
+      min: "Parameter %{name} cannot be less than %{min}"

--- a/lib/rails_param.rb
+++ b/lib/rails_param.rb
@@ -1,4 +1,10 @@
+# frozen_string_literal: true
+
 require 'rails_param/param'
+require 'i18n'
+I18n.load_path += Dir[File.expand_path("i18n/locales") + "/*.yml"]
+I18n.default_locale = :en
+
 Dir[File.join(__dir__, 'rails_param/validator', '*.rb')].sort.each { |file| require file }
 Dir[File.join(__dir__, 'rails_param/coercion', '*.rb')].sort.reverse.each { |file| require file }
 Dir[File.join(__dir__, 'rails_param', '*.rb')].sort.each { |file| require file }

--- a/lib/rails_param/param_evaluator.rb
+++ b/lib/rails_param/param_evaluator.rb
@@ -27,7 +27,7 @@ module RailsParam
       # validate presence
       if params[name].nil? && options[:required]
         raise InvalidParameterError.new(
-          "Parameter #{parameter_name} is required",
+          I18n.t('rails_param.errors.required', name: parameter_name),
           param: parameter_name,
           options: options
         )
@@ -64,7 +64,7 @@ module RailsParam
     end
 
     def recurse(element, context, index = nil)
-      raise InvalidParameterError, 'no block given' unless block_given?
+      raise InvalidParameterError, I18n.t('rails_param.errors.no_block') unless block_given?
 
       yield(ParamEvaluator.new(element, context), index)
     end
@@ -80,7 +80,9 @@ module RailsParam
 
         Coercion.new(param, type, options).coerce
       rescue ArgumentError, TypeError
-        raise InvalidParameterError.new("'#{param}' is not a valid #{type}", param: param_name)
+        raise InvalidParameterError.new(I18n.t('rails_param.errors.invalid_type',
+                                               **options.merge({ name: param_name, value: param, type: type })),
+                                        param: param_name, options: options.merge({ type: type, value: param }))
       end
     end
 

--- a/lib/rails_param/validator.rb
+++ b/lib/rails_param/validator.rb
@@ -51,8 +51,12 @@ module RailsParam
       string.split('_').collect(&:capitalize).join
     end
 
+    def error_type
+      self.class.name.split('::').last.underscore
+    end
+
     def error_message
-      nil
+      I18n.t("rails_param.errors.#{error_type}", **(options.merge({ name: name, value: value })))
     end
 
     def valid_value?

--- a/lib/rails_param/validator/blank.rb
+++ b/lib/rails_param/validator/blank.rb
@@ -13,12 +13,6 @@ module RailsParam
           !value.nil?
         end
       end
-
-      private
-
-      def error_message
-        "Parameter #{name} cannot be blank"
-      end
     end
   end
 end

--- a/lib/rails_param/validator/format.rb
+++ b/lib/rails_param/validator/format.rb
@@ -10,9 +10,9 @@ module RailsParam
       TIME_TYPES = [Date, DateTime, Time].freeze
       STRING_OR_TIME_TYPES = ([String] + TIME_TYPES).freeze
 
-      def error_message
-        "Parameter #{name} must be a string if using the format validation" unless matches_string_or_time_types?
-        "Parameter #{name} must match format #{options[:format]}" unless string_in_format?
+      def error_type
+        :invalid_string_or_time unless matches_string_or_time_types?
+        :invalid_string_format unless string_in_format?
       end
 
       def matches_time_types?
@@ -25,6 +25,12 @@ module RailsParam
 
       def string_in_format?
         value =~ options[:format] && value.kind_of?(String)
+      end
+
+      # because format is reserved keyword in i18n and raise ReservedInterpolationKey
+      def error_message
+        I18n.t("rails_param.errors.#{error_type}",
+               **options.merge({ name: name, value: value, format_pattern: options[:format] }))
       end
     end
   end

--- a/lib/rails_param/validator/in.rb
+++ b/lib/rails_param/validator/in.rb
@@ -9,12 +9,6 @@ module RailsParam
                         Array(options[:in]).include?(value)
                       end
       end
-
-      private
-
-      def error_message
-        "Parameter #{parameter.name} must be within #{parameter.options[:in]}"
-      end
     end
   end
 end

--- a/lib/rails_param/validator/is.rb
+++ b/lib/rails_param/validator/is.rb
@@ -4,12 +4,6 @@ module RailsParam
       def valid_value?
         value === options[:is]
       end
-
-      private
-
-      def error_message
-        "Parameter #{name} must be #{options[:is]}"
-      end
     end
   end
 end

--- a/lib/rails_param/validator/max.rb
+++ b/lib/rails_param/validator/max.rb
@@ -4,12 +4,6 @@ module RailsParam
       def valid_value?
         value.nil? || options[:max] >= value
       end
-
-      private
-
-      def error_message
-        "Parameter #{name} cannot be greater than #{options[:max]}"
-      end
     end
   end
 end

--- a/lib/rails_param/validator/max_length.rb
+++ b/lib/rails_param/validator/max_length.rb
@@ -4,12 +4,6 @@ module RailsParam
       def valid_value?
         value.nil? || options[:max_length] >= value.length
       end
-
-      private
-
-      def error_message
-        "Parameter #{name} cannot have length greater than #{options[:max_length]}"
-      end
     end
   end
 end

--- a/lib/rails_param/validator/min.rb
+++ b/lib/rails_param/validator/min.rb
@@ -4,12 +4,6 @@ module RailsParam
       def valid_value?
         value.nil? || options[:min] <= value
       end
-
-      private
-
-      def error_message
-        "Parameter #{name} cannot be less than #{options[:min]}"
-      end
     end
   end
 end

--- a/lib/rails_param/validator/min_length.rb
+++ b/lib/rails_param/validator/min_length.rb
@@ -4,12 +4,6 @@ module RailsParam
       def valid_value?
         value.nil? || options[:min_length] <= value.length
       end
-
-      private
-
-      def error_message
-        "Parameter #{name} cannot have length less than #{options[:min_length]}"
-      end
     end
   end
 end

--- a/lib/rails_param/validator/required.rb
+++ b/lib/rails_param/validator/required.rb
@@ -6,10 +6,6 @@ module RailsParam
       def valid_value?
         !(value.nil? && options[:required])
       end
-
-      def error_message
-        "Parameter #{name} is required"
-      end
     end
   end
 end


### PR DESCRIPTION
…ssages

Pass needed values when raise InvalidParameterError to make it avalible to users

## Description
A few sentences describing the overall goals of the pull request's commits.
Link to related issues if any. (As `Fixes #XXX`)
make gem support localization and users can customize their error as they need
## Todos
List any remaining work that needs to be done, i.e:
- [ x] Tests
- [x ] Documentation

## Additional Notes
Optional section
